### PR TITLE
Total models wasn't using query filters

### DIFF
--- a/src/Flare/Admin/Models/Traits/ModelQuerying.php
+++ b/src/Flare/Admin/Models/Traits/ModelQuerying.php
@@ -178,7 +178,7 @@ trait ModelQuerying
                     ];
         }
 
-        return ['all' => $this->model->count()];
+        return ['all' => $this->items($count = true)];
     }
 
     /**


### PR DESCRIPTION
When getting the totals for a model, which doesn't have soft deletes, the total is just a count of the model. This should apply the same query filters as the list