### PR TITLE
Changed getTitle method to use preg_replace

### DIFF
--- a/src/Flare/Admin/Admin.php
+++ b/src/Flare/Admin/Admin.php
@@ -293,7 +293,7 @@ abstract class Admin
     public function getTitle()
     {
         if (!isset($this->title) || !$this->title) {
-            return Str::title(str_replace('_', ' ', snake_case(str_replace(static::CLASS_SUFFIX, '', static::shortName()))));
+            return Str::title(str_replace('_', ' ', snake_case(preg_replace('/'.static::CLASS_SUFFIX.'$/', '', static::shortName()))));
         }
 
         return $this->title;


### PR DESCRIPTION
Changed the str_replace for a preg_replace which replaces at the end of the string.
This means it is then possible to have a class called AdministratorAdmin or similar.